### PR TITLE
[Goody] 발신모드 기능 추가

### DIFF
--- a/martian/public/javascripts/dom.js
+++ b/martian/public/javascripts/dom.js
@@ -6,7 +6,8 @@ const dom = {
     
     strInfo: {
         input : document.querySelector(".str_info_input"),
-        button : document.querySelector(".str_info_submit")
+        button : document.querySelector(".str_info_submit"),
+        str : document.querySelector(".str_from_hex")
     },
     
     modeInfo: {

--- a/martian/public/javascripts/main.js
+++ b/martian/public/javascripts/main.js
@@ -46,24 +46,8 @@ const runMode = (mode) => {
 
 
 const runReceiveMode = () => {
-    const SECONDS = 1000;
-    const timer = () => {
-        setTimeout(() => {
-            const firstChar = hexMsg.slice(0, 1);
-            hexMsg = hexMsg.substring(1);
-            if (dom.modeInfo.str.innerHTML !== "수신모드") return;
-            if (firstChar !== "") {
-                rotateArrow(firstChar);
-                updateHexInfo(firstChar);
-                timer();
-            } else {
-                clearTimeout();
-                activeBtn(dom.hexInfo.button);
-            }
 
-        }, SECONDS);
-    }
-    timer();
+    timer(1000, "수신모드");
 }
 
 const activeBtn = (button) => {
@@ -78,38 +62,69 @@ const rotateArrow = (char) => {
 }
 
 const updateHexInfo = (char) => {
-    
+
     dom.hexInfo.input.value += char;
-    
-    if(dom.hexInfo.input.value.length % 3 === 0) {
+
+    if (dom.hexInfo.input.value.length % 3 === 0) {
         dom.hexInfo.input.value = dom.hexInfo.input.value.slice(0, -1);
         dom.hexInfo.input.value += " " + char;
     }
 }
 
-const runSendMode = () => {
-    //   console.log("sendMode run")
+const updateRealtimeStr = () => {
+    setTimeout(() => {
+        dom.strInfo.str.innerHTML = getHexFromMsg(dom.strInfo.input.value);
+        updateRealtimeStr();
+    }, 0);
 }
 
+const timer = (seconds, mode) => {
+    setTimeout(() => {
+        const firstChar = hexMsg.slice(0, 1);
+        hexMsg = hexMsg.substring(1);
+        if (dom.modeInfo.str.innerHTML !== mode) return;
+        if (firstChar !== "") {
+            rotateArrow(firstChar);
+            updateHexInfo(firstChar);
+            timer(1000, mode);
+        } else {
+            clearTimeout();
+            activeBtn(dom.hexInfo.button);
+        }
 
-const onEvent = (target, event, func) => {
-    target.addEventListener(`${event}`, () => {
-        func();
+    }, seconds);
+}
+
+const runSendMode = () => {
+    console.log("sendMode run");
+
+
+    dom.strInfo.button.addEventListener('click', () => {
+        hexMsg = dom.strInfo.str.innerHTML;
+
+        timer(1000, "발신모드");
     });
 }
 
-const translate = () => {
-    const message = getEngFromHex(dom.hexInfo.input.value);
-     
-    alert(message);
-}
+const onEvent = (target, event, func) => {
+        target.addEventListener(`${event}`, () => {
+            func();
+        });
+    }
 
-const init = () => {
-    onEvent(dom.hexInfo.button, 'click', translate);
-    drawCircle();
-    renderNumbers();
-    toggleMode("click", dom.modeInfo.button, dom.modeInfo.str, [dom.hexInfo.button, dom.strInfo.button]);
-    runMode(dom.modeInfo.str.innerHTML);
-}
+    const translate = () => {
+        const message = getEngFromHex(dom.hexInfo.input.value);
 
-init();
+        alert(message);
+    }
+
+    const init = () => {
+        onEvent(dom.hexInfo.button, 'click', translate);
+        drawCircle();
+        renderNumbers();
+        toggleMode("click", dom.modeInfo.button, dom.modeInfo.str, [dom.hexInfo.button, dom.strInfo.button]);
+        runMode(dom.modeInfo.str.innerHTML);
+        updateRealtimeStr();
+    }
+
+    init();

--- a/martian/views/index.ejs
+++ b/martian/views/index.ejs
@@ -25,6 +25,7 @@
     <h1>발신정보입력</h1>
     <input placeholder="문자열" class = "str_info_input">
     <button class = "str_info_submit"  disabled = true>지구로 보내기</button>
+    <div class = "str_from_hex"></div>
   </div>
 
   <div class = mode_info>


### PR DESCRIPTION
## To Do

- [x] **초기화**

  - [x] 발신모드에선 -> 해석하기 버튼 비활성화 /  수신모드에선 -> 모든 버튼 비활성화
  - [x] 모드 전환될 때마다 모든 입력 초기화

- [x] **발신모드**

  - [x] 오른쪽 빈칸에 문자열 입력하고 지구로 보내기 누르면 글자 하나 하나 16진수로 변환 -> 배열
  - [x] 16진수들이 담긴  배열 내 원소를 화살표가 가리킴(2초) -> 가리킨 숫자를 왼쪽 빈칸에 출력

- [x] **수신모드**

  - [x] 5초 간격으로 어디선가 받아온 메시지(16진수 문자열)를 확인
  - [x] 메시지(16진수 문자열)를 확인 하자마자 화살표가 해당 숫자 가리킴(2초간) 
  - [x] 화살표가 2초간 가리킨 숫자를 왼쪽 입력칸에 업데이트
  - [x] 메시지 읽기 -> 화살표 가리키기 과정이 모두 끝나면 해석하기 버튼 활성화
  - [x] 해석하기 버튼 누르면 왼쪽 입력칸에 쓰인 16진수 문자열을 영어로 변환, alert() 로 띄우기   

   
## 회고

Promise 는 활용하지 못했지만 `setTimeout` 이랑 많이 친해진 미션이었던 것 같습니다.
남은 주말은 myPromise를 만들어보면서 보내야겠네요.
이번 주도 다들 고생 많으셨습니다!
